### PR TITLE
Fix for $version null & string

### DIFF
--- a/Model/ChangelogVersionSnapshot.php
+++ b/Model/ChangelogVersionSnapshot.php
@@ -14,10 +14,10 @@ class ChangelogVersionSnapshot
      * Set changelog version
      *
      * @param string $changelogName
-     * @param int $version
+     * @param int|null $version
      * @return void
      */
-    public function setChangelogVersion(string $changelogName, int $version): void
+    public function setChangelogVersion(string $changelogName, ?int $version): void
     {
         $this->changelogVersions[$changelogName] = $version;
     }

--- a/Plugin/Mview/StoreChangelogVersionsSnapshot.php
+++ b/Plugin/Mview/StoreChangelogVersionsSnapshot.php
@@ -60,7 +60,8 @@ class StoreChangelogVersionsSnapshot
         }
         $changelogVersions = $this->getChangelogVersions($changelogs);
         foreach ($changelogVersions as $changelogName => $version) {
-            $this->changelogVersionSnapshot->setChangelogVersion($changelogName, $version);
+            $this->changelogVersionSnapshot->setChangelogVersion($changelogName,
+                $version ? (int)$version : null);
         }
     }
 


### PR DESCRIPTION
SWG was failing when running indexer_update_all_views due to string & null conversions.
ie:
`[2023-01-23T23:32:03.947228+00:00] main.ERROR: Cron Job indexer_update_all_views has an error: Aligent\IndexerFix\Model\ChangelogVersionSnapshot::setChangelogVersion(): Argument #2 ($version) must be of type int, null given, called in /app/vcg4nleovhbh2_stg/vendor/aligent/magento2-indexer-fix/Plugin/Mview/StoreChangelogVersionsSnapshot.php on line 63. Statistics: {"sum":0,"count":1,"realmem":0,"emalloc":0,"realmem_start":284164096,"emalloc_start":269257904} [] []
[2023-01-23T23:32:03.951548+00:00] main.CRITICAL: TypeError: Aligent\IndexerFix\Model\ChangelogVersionSnapshot::setChangelogVersion(): Argument #2 ($version) must be of type int, null given, called in /app/vcg4nleovhbh2_stg/vendor/aligent/magento2-indexer-fix/Plugin/Mview/StoreChangelogVersionsSnapshot.php on line 63 and defined in /app/vcg4nleovhbh2_stg/vendor/aligent/magento2-indexer-fix/Model/ChangelogVersionSnapshot.php:20`

![2023-01-24_14-07](https://user-images.githubusercontent.com/5354794/214207495-41088291-5cdf-4ab2-9fa4-62ff411dd8eb.png)

